### PR TITLE
allow all servernames for connection

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import svgLoader from 'vite-svg-loader'
 export default defineConfig({
   plugins: [vue(), svgLoader()],
   server: {
-    host: true
+    host: true,
+    allowedHosts: true
   }
 })


### PR DESCRIPTION
This PR adds a config option to vite.config.js to allow connection on any hostname.
This is required for running lcars with the Dockerfile behind a reverse proxy.